### PR TITLE
Make LightOrbEntity not render it's name and make splash potions not interact with them

### DIFF
--- a/src/main/java/ladysnake/illuminations/common/entities/LightOrbEntity.java
+++ b/src/main/java/ladysnake/illuminations/common/entities/LightOrbEntity.java
@@ -23,6 +23,11 @@ public abstract class LightOrbEntity extends FlyingEntity {
     }
 
     @Override
+    public boolean isAffectedBySplashPotions(){
+        return false;
+    }
+
+    @Override
     public boolean shouldRenderName() {
         return false;
     }

--- a/src/main/java/ladysnake/illuminations/common/entities/LightOrbEntity.java
+++ b/src/main/java/ladysnake/illuminations/common/entities/LightOrbEntity.java
@@ -23,6 +23,11 @@ public abstract class LightOrbEntity extends FlyingEntity {
     }
 
     @Override
+    public boolean shouldRenderName() {
+        return false;
+    }
+
+    @Override
     public boolean hasNoGravity() {
         return true;
     }


### PR DESCRIPTION
It's already not possible to give them names with nametags, but other mods such as https://github.com/HyperPigeon/Eldritch-Mobs can give them names, causing weird FireFlies with large nametags to fly around everywhere. By changing this to false nametags will never render.