### PR TITLE
Fix NPE if PLAYER_AURAS couldn't be set

### DIFF
--- a/src/main/java/ladysnake/illuminations/mixin/PlayerEntityMixin.java
+++ b/src/main/java/ladysnake/illuminations/mixin/PlayerEntityMixin.java
@@ -21,7 +21,7 @@ public abstract class PlayerEntityMixin extends LivingEntity {
     @Inject(method = "tick", at = @At("RETURN"))
     public void tick(CallbackInfo callbackInfo) {
         // if player has an aura
-        if (IlluminationsClient.PLAYER_AURAS.has(this.getUuid().toString())) {
+        if (IlluminationsClient.PLAYER_AURAS != null && IlluminationsClient.PLAYER_AURAS.has(this.getUuid().toString())) {
             String playerAura = IlluminationsClient.PLAYER_AURAS.getAsJsonObject(this.getUuid().toString()).get("aura").getAsString();
 
             // do not render in first person or if the player is invisible


### PR DESCRIPTION
If PLAYER_AURAS was never set, possibly due to an I/O error, PLAYER_AURAS will be `null`, and that causes an NPE upon loading a world if left that way. This is meant to prevent that by checking if it isn't `null`.