### PR TITLE
:feat: cache for month

### DIFF
--- a/src/main/java/ladysnake/illuminations/client/Illuminations.java
+++ b/src/main/java/ladysnake/illuminations/client/Illuminations.java
@@ -75,6 +75,7 @@ public class Illuminations implements ClientModInitializer {
     public static final int EYES_VANISHING_DISTANCE = 5;
     public static final Gson COSMETICS_GSON = new GsonBuilder().registerTypeAdapter(PlayerCosmeticData.class, new PlayerCosmeticDataParser()).create();
     // spawn predicates
+    private static final boolean IS_OCTOBER = LocalDate.now().getMonth() == Month.OCTOBER;
     public static final BiPredicate<World, BlockPos> FIREFLY_LOCATION_PREDICATE = (world, blockPos) -> {
         Block block = world.getBlockState(blockPos).getBlock();
         return world.getDimension().hasFixedTime()
@@ -85,7 +86,7 @@ public class Illuminations implements ClientModInitializer {
     };
     public static final BiPredicate<World, BlockPos> GLOWWORM_LOCATION_PREDICATE = (world, blockPos) -> world.getBlockState(blockPos).getBlock() == Blocks.CAVE_AIR;
     public static final BiPredicate<World, BlockPos> PLANKTON_LOCATION_PREDICATE = (world, blockPos) -> world.getBlockState(blockPos).getFluidState().isIn(FluidTags.WATER) && world.getLightLevel(blockPos) < 2;
-    public static final BiPredicate<World, BlockPos> EYES_LOCATION_PREDICATE = (world, blockPos) -> ((Config.getHalloweenFeatures() == HalloweenFeatures.ENABLE && LocalDate.now().getMonth() == Month.OCTOBER) || Config.getHalloweenFeatures() == HalloweenFeatures.ALWAYS) && (world.getBlockState(blockPos).getBlock() == Blocks.AIR || world.getBlockState(blockPos).getBlock() == Blocks.CAVE_AIR) && world.getLightLevel(blockPos) <= 0 && world.getClosestPlayer(blockPos.getX(), blockPos.getY(), blockPos.getZ(), EYES_VANISHING_DISTANCE, false) == null && world.getRegistryKey().equals(World.OVERWORLD);
+    public static final BiPredicate<World, BlockPos> EYES_LOCATION_PREDICATE = (world, blockPos) -> ((Config.getHalloweenFeatures() == HalloweenFeatures.ENABLE && IS_OCTOBER) || Config.getHalloweenFeatures() == HalloweenFeatures.ALWAYS) && (world.getBlockState(blockPos).getBlock() == Blocks.AIR || world.getBlockState(blockPos).getBlock() == Blocks.CAVE_AIR) && world.getLightLevel(blockPos) <= 0 && world.getClosestPlayer(blockPos.getX(), blockPos.getY(), blockPos.getZ(), EYES_VANISHING_DISTANCE, false) == null && world.getRegistryKey().equals(World.OVERWORLD);
     public static final BiPredicate<World, BlockPos> WISP_LOCATION_PREDICATE = (world, blockPos) -> world.getBlockState(blockPos).isIn(BlockTags.SOUL_FIRE_BASE_BLOCKS);
     // register overhead models
     public static final EntityModelLayer CROWN = new EntityModelLayer(new Identifier(MODID, "crown"), "main");

--- a/src/main/java/ladysnake/illuminations/mixin/ClientWorldMixin.java
+++ b/src/main/java/ladysnake/illuminations/mixin/ClientWorldMixin.java
@@ -1,6 +1,7 @@
 package ladysnake.illuminations.mixin;
 
 import com.google.common.collect.ImmutableSet;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceLinkedOpenHashMap;
 import ladysnake.illuminations.client.Illuminations;
 import ladysnake.illuminations.client.config.Config;
 import ladysnake.illuminations.client.data.IlluminationData;
@@ -69,7 +70,7 @@ public abstract class ClientWorldMixin extends World {
         illuminationDataSet.forEach(illuminationData -> {
             if (illuminationData.locationSpawnPredicate().test(this, pos)
                     && illuminationData.shouldAddParticle(this.random)) {
-                this.addParticle(illuminationData.illuminationType(), (double) pos.getX(), (double) pos.getY(), (double) pos.getZ(), 0.0D, 0.0D, 0.0D);
+                this.addParticle(illuminationData.illuminationType(), pos.getX(), pos.getY(), pos.getZ(), 0.0D, 0.0D, 0.0D);
             }
         });
     }


### PR DESCRIPTION
fix #101 

Block & Biome cache aren't effective. 

Cache for month
	- Before:
    ![Pasted image 20211014112308](https://user-images.githubusercontent.com/19922286/137281169-3f01d3e6-2a9c-4069-9c80-2ac99550fc9d.png)
	- After:
	![Pasted image 20211014112304](https://user-images.githubusercontent.com/19922286/137281152-7a7cbbe6-702b-4d9f-9dd8-4cb23d748092.png)